### PR TITLE
Add trailing slash to custom paths

### DIFF
--- a/lib/src/peer.dart
+++ b/lib/src/peer.dart
@@ -33,7 +33,7 @@ class Peer extends StreamEventEmitter {
 
     // Set path correctly.
     if (_options.path != '/') {
-      _options.path = '/${_options.path}';
+      _options.path = '${_options.path}/';
     }
 
     // Set a custom log function if present


### PR DESCRIPTION
Hi! I tried using peerdart with my own server and kept getting an error retrieving the ID. I checked the URL that it generated and it turned out that the URL is missing a slash. This should fix it. Please let me know your thoughts.

Thanks!